### PR TITLE
export as target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,9 @@ if(CMAKE_CXX_STANDARD LESS 11)
 endif()
 
 add_library(ghc_filesystem INTERFACE)
-target_sources(ghc_filesystem INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/filesystem.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/fs_fwd.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/fs_impl.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/fs_std.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/fs_std_fwd.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/ghc/fs_std_impl.hpp
-)
-target_include_directories(ghc_filesystem INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(ghc_filesystem INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 target_compile_options(ghc_filesystem INTERFACE "$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 target_compile_options(ghc_filesystem INTERFACE "$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 
@@ -46,14 +40,5 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-set(PACKAGECONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-
-configure_package_config_file(cmake/config.cmake.in
-	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	INSTALL_DESTINATION ${PACKAGECONFIG_INSTALL_DIR}
-	PATH_VARS INCLUDE_INSTALL_DIR)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	DESTINATION ${PACKAGECONFIG_INSTALL_DIR})
+install(TARGETS ghc_filesystem EXPORT ghcFilesystemConfig)
+install(EXPORT ghcFilesystemConfig NAMESPACE ghcFilesystem:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ghcFilesystem)


### PR DESCRIPTION
This is trying to export `ghc-filesystem` as a target, so you can include it with `ghcFilesystem::ghc_filesystem` in cmake projects.

I am not completely sure if I broke something that was existing before, but it seems to be working for me. Let me know what you think.