### PR TITLE
Fix missing string_view path method

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -1475,6 +1475,15 @@ inline path::path(const std::u32string& source, format fmt)
     postprocess_path_with_format(_path, fmt);
 }
 
+#ifdef __cpp_lib_string_view
+template <>
+inline path::path(const std::string_view& source, format fmt)
+{
+    _path = detail::toUtf8(std::string(source));
+    postprocess_path_with_format(_path, fmt);
+}
+#endif
+
 template <class Source, typename>
 inline path u8path(const Source& source)
 {


### PR DESCRIPTION
This is needed to be able to compile using a c++17 standard library for both gcc and clang.