### PR TITLE
Fix storage deprecation warning when in C++17 mode

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -204,8 +204,10 @@ public:
 #endif
 };
 
+#if  __cplusplus < 201703L
 template <typename char_type>
 constexpr char_type path_helper_base<char_type>::preferred_separator;
+#endif
     
 // 30.10.8 class path
 class GHC_FS_API_CLASS path


### PR DESCRIPTION
Fixes `"error: redundant redeclaration of 'constexpr' static data member 'ghc::filesystem::path_helper_base<char_type>::preferred_separator' [-Werror=deprecated]"` when compiling with GCC 7.4 in `-std=c++17` mode.