### PR TITLE
Add FreeBSD build on Cirrus CI

### DIFF
--- a/.ci/unix-build.sh
+++ b/.ci/unix-build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .

--- a/.ci/unix-test.sh
+++ b/.ci/unix-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd build
+ctest -E Windows
+if [ -f "test/std_filesystem_test" ]; then
+  test/std_filesystem_test || true
+fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,13 @@
+freebsd_instance:
+  image_family: freebsd-12-1
+
+task:
+  install_script: |
+    pkg install -y cmake
+    pw groupadd testgrp
+    pw useradd testuser -g testgrp -w none -m
+    chown -R testuser:testgrp .
+  build_script: |
+    sudo -u testuser .ci/unix-build.sh
+  test_script: |
+    sudo -u testuser .ci/unix-test.sh


### PR DESCRIPTION
Not sure if you want this, but as part of getting HELICS building on FreeBSD I wanted to confirm that ghc::filesystem works and setting up a build on CI seemed easier at the time than setting up my own local VM.

Cirrus CI provides an easy setup to get builds running in FreeBSD VMs. This also gives some way of testing the resent changes in commit https://github.com/gulrak/filesystem/commit/c193676fe9d661510192a6d42090aa65183b87b4. The GitHub App for adding the integration to the repository is https://github.com/marketplace/cirrus-ci.