### PR TITLE
Add ARM builds on Drone CI

### DIFF
--- a/.ci/unix-build.sh
+++ b/.ci/unix-build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .

--- a/.ci/unix-test.sh
+++ b/.ci/unix-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd build
+ctest -E Windows
+if [ -f "test/std_filesystem_test" ]; then
+  test/std_filesystem_test || true
+fi

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,43 @@
+kind: pipeline
+name: arm
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: alpine
+  failure: ignore
+  commands:
+  - apk update
+  - apk add --no-cache build-base cmake sudo
+  - addgroup testgrp
+  - adduser --disabled-password testuser testgrp
+  - passwd testuser -u -d
+  - chown -R testuser:testgrp .
+  - sudo -u testuser .ci/unix-build.sh
+  - sudo -u testuser .ci/unix-test.sh
+
+---
+
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: alpine
+  failure: ignore
+  commands:
+  - apk update
+  - apk add --no-cache build-base cmake
+  - addgroup testgrp
+  - adduser --disabled-password testuser testgrp
+  - passwd testuser -u -d
+  - chown -R testuser:testgrp .
+  - su -c "./.ci/unix-build.sh" testuser
+  - su -c "./.ci/unix-test.sh" testuser


### PR DESCRIPTION
This was another test to see if the libraries we're using work on ARM processors that you can have if you want it. It shares the build/test scripts with the FreeBSD build.

The tests run on actual ARM systems (Cavium Thunder processors, I think), with both 32 and 64 bit builds. Setting up the service is at https://cloud.drone.io/ -- basically adding a webhook to the project.