### PR TITLE
Bug - Leading Whitespace On Stream In

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -2951,7 +2951,8 @@ template <class charT, class traits>
 inline std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>& is, path& p)
 {
     std::basic_string<charT, traits> tmp;
-    auto c = is.get();
+    charT c;
+    is >> c;
     if (c == '"') {
         auto sf = is.flags();
         is >> std::noskipws;


### PR DESCRIPTION
There is an issue where leading whitespace in an input stream buffer causes a `path` to be invalid.

To reproduce:
```c++
fs::path path;
std::istringstream ss("line text.txt");
std::string directive;
ss >> directive >> path;

std::ifstream fileIn(path); // tries to open " text.txt" (leading space, nonexistent file)
assert (fileIn); // assertion fails when using ghc::filesystem
```

See a compiling example [here.](https://github.com/jnhyatt/fs-test) This was tested using MSVC 16.4.5 and g++ 9.1.0. In both configurations, `std::filesystem` behaves as expected (run `std-fs` in the root directory) where `ghc::filesystem` returns a path with a leading space and fails to properly parse when handed to `std::ifstream` (run `alt-fs` in the root directory).

The fix simply streams in the first character when testing for a quote character. This causes the operation to respect the current `skipws` flag. Using `std::basic_istream::get()` will ignore the `skipws` flag and simply read in the first character (if there is leading whitespace, a whitespace character). If the `skipws` flag is set in the `istream`, both `std::filesystem` and `ghc::filesystem` read in the whitespace character and fail the assertion.