### PR TITLE
lexically_relative: ignore trailing slash on base

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -2683,7 +2683,7 @@ GHC_INLINE path path::lexically_relative(const path& base) const
     }
     int count = 0;
     for (const auto& element : input_iterator_range<const_iterator>(b, base.end())) {
-        if (element != "." && element != "..") {
+        if (element != "." && element != "" && element != "..") {
             ++count;
         }
         else if (element == "..") {

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -882,6 +882,7 @@ TEST_CASE("30.10.8.4.11 path generation", "[filesystem][path][fs.path.gen]")
     CHECK(fs::path("a/b/c").lexically_relative("a/b/c/x/y") == "../..");
     CHECK(fs::path("a/b/c").lexically_relative("a/b/c") == ".");
     CHECK(fs::path("a/b").lexically_relative("c/d") == "../../a/b");
+    CHECK(fs::path("a/b").lexically_relative("a/") == "b");
     if (has_host_root_name_support()) {
         CHECK(fs::path("//host1/foo").lexically_relative("//host2.bar") == "");
     }


### PR DESCRIPTION
Previously,

```c++
fs::path("a/b").lexically_relative("a/")
```

would incorrectly return `"../b"`. Now it returns `"b"`.

Fixes #56 