### PR TITLE
directory_iterator: Skip entry if there was an error creating it.

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -4904,6 +4904,10 @@ public:
                     _current = _base;
                     _current.append_name(_entry->d_name);
                     _dir_entry = directory_entry(_current, ec);
+                    if(ec) {
+                        ec.clear();
+                        continue;
+                    }
                 }
                 else {
                     ::closedir(_dir);


### PR DESCRIPTION
Hi!

So, I've been trying to debug some issues we have in our game scanner in [Play!](https://github.com/jpd002/Play-) on Android. We are using `ghc_filesystem` to scan the filesystem for files that can be used by the emulator (code [here](https://github.com/jpd002/Play-/blob/master/Source/ui_shared/BootablesProcesses.cpp#L51)).

One issue I've identified is that inside the `directory_iterator::impl::increment` function, `readdir` seems to return an entry that can't be `lstat`'ed (returns -1). I'm still trying to see what's weird about that entry, but it's causing the `directory_iterator` constructor to throw an exception and aborting the scanning process for that directory (which happens to be the root of the sdcard filesystem in my case).

The PR here is a workaround for that problem, but I'm not sure this is the proper fix. I think the expected behavior would be to allow a `directory_entry` to be created with that entry without an error, even though other operations, such as `fs::is_directory` would fail (which would be ok).

Lemme know what you think!