### PR TITLE
Link with -lrt (for glibc versions before 2.17)

### DIFF
--- a/cmake/GhcHelper.cmake
+++ b/cmake/GhcHelper.cmake
@@ -12,7 +12,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND (CMAKE_CXX_COMPILER_VERSION 
             target_link_libraries(${targetName} -lc++fs)
         else()
             target_compile_options(${targetName} PRIVATE "-stdlib=libc++")
-            target_link_libraries(${targetName} -stdlib=libc++ -lc++fs)
+            target_link_libraries(${targetName} -stdlib=libc++ -lc++fs $<$<PLATFORM_ID:Linux>:rt>)
         endif()
     else()
         if(NOT APPLE)


### PR DESCRIPTION
Fix link error on system with old glibc and old clang (7 - 8):

```
[  1%] Linking CXX executable std_filesystem_test
cd /home/.../ghc-filesystem/test && /opt/cmake/cmake-3.17.2-Linux-x86_64/bin/cmake -E cmake_link_script CMakeFiles/std_filesystem_test.dir/link.txt --verbose=1
/opt/llvm/clang+llvm-8.0.1-x86_64-linux-sles11.3/bin/clang++  -m64 -stdlib=libc++ -msse -msse2 -msse3 -mssse3 -Wall -Wextra -O3 -DNDEBUG -flto=thin  -fuse-ld=lld -Wl,--build-id=sha1 -Wl,--disable-new-dtags CMakeFiles/std_filesystem_test.dir/filesystem_test.cpp.o  -o std_filesystem_test  -stdlib=libc++ -lc++fs
ld.lld: error: undefined symbol: clock_gettime
>>> referenced by operations.cpp
>>>               operations.cpp.o:(std::__1::__fs::filesystem::_FilesystemClock::now()) in archive /opt/llvm/clang+llvm-8.0.1-x86_64-linux-sles11.3/bin/../lib/libc++fs.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```