### PR TITLE
Fixed detection of the AppleClang compiler

### DIFF
--- a/cmake/GhcHelper.cmake
+++ b/cmake/GhcHelper.cmake
@@ -48,7 +48,7 @@ macro(AddTestExecutableWithStdCpp cppStd)
     target_link_libraries(filesystem_test_cpp${cppStd} ghc_filesystem)
     target_compile_options(filesystem_test_cpp${cppStd} PRIVATE
             $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
-            $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -Wno-error=deprecated-declarations>
+            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -Wno-error=deprecated-declarations>
             $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror -Wno-error=deprecated-declarations>
             $<$<CXX_COMPILER_ID:MSVC>:/WX /wd4996>)
     if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
     target_link_libraries(filesystem_test ghc_filesystem)
     target_compile_options(filesystem_test PRIVATE
         $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
-        $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror>
         $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror>
         $<$<CXX_COMPILER_ID:MSVC>:/WX>)
     if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)


### PR DESCRIPTION
See:
https://cmake.org/cmake/help/v3.7/policy/CMP0025.html
https://stackoverflow.com/questions/53410514/cmake-compiler-cxx-id-behaviour/53629796#53629796