### PR TITLE
using static_cast instead of old style cast

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -1797,7 +1797,7 @@ GHC_INLINE bool equals_simple_insensitive(const path::value_type* str1, const pa
 
 GHC_INLINE int compare_simple_insensitive(const path::value_type* str1, size_t len1, const path::value_type* str2, size_t len2)
 {
-    while (len1 > 0 && len2 > 0 && ::tolower((unsigned char)*str1) == ::tolower((unsigned char)*str2)) {
+    while (len1 > 0 && len2 > 0 && ::tolower(static_cast<unsigned char>(*str1)) == ::tolower(static_cast<unsigned char>(*str2))) {
         --len1;
         --len2;
         ++str1;


### PR DESCRIPTION
This is a warning in GCC when using `-Wold-style-cast`