### PR TITLE
Improved string_view support (v2)

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -240,6 +240,9 @@
 #define GHC_HAS_STD_EXPERIMENTAL_STRING_VIEW
 #elif defined(__GNUC__) && (((__GNUC__ == 4) && (__GNUC_MINOR__ >= 9)) || (__GNUC__ > 4)) && (__cplusplus >= 201402)
 #define GHC_HAS_STD_EXPERIMENTAL_STRING_VIEW
+#elif defined(__GLIBCXX__) && defined(_GLIBCXX_USE_DUAL_ABI) && (__cplusplus >= 201402)
+// macro _GLIBCXX_USE_DUAL_ABI is always defined in libstdc++ from gcc-5 and newer
+#define GHC_HAS_STD_EXPERIMENTAL_STRING_VIEW
 #endif
 
 #if defined(GHC_HAS_STD_STRING_VIEW)


### PR DESCRIPTION
The ``__GNUC__`` macro is not suitable for detecting ``libstdc++`` version when using ``clang++ -stdlib=libstdc++``.
