### PR TITLE
Fix `create_directories` for windows long paths

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3902,7 +3902,7 @@ GHC_INLINE bool create_directories(const path& p, std::error_code& ec) noexcept
     bool didCreate = false;
     for (path::string_type part : p) {
         current /= part;
-        if (current != p.root_name() && current != p.root_path()) {
+        if (current != p.root_name() && current != p.root_path() && current != GHC_PLATFORM_LITERAL("\\\\?\\")) {
             std::error_code tec;
             auto fs = status(current, tec);
             if (tec && fs.type() != file_type::not_found) {

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -2861,6 +2861,12 @@ TEST_CASE("Windows: Long filename support", "[filesystem][path][fs.path.win.long
         }
     }
     CHECK(c <= 'Z');
+
+    fs::remove(fs::current_path().u8string() + std::string(16, 'A'));
+    CHECK_NOTHROW(fs::create_directories(dir));
+    CHECK(fs::exists(dir));
+    generateFile(dir / "f0");
+    CHECK(fs::exists(dir / "f0"));
 #else
     WARN("Windows specific tests are empty on non-Windows systems.");
 #endif


### PR DESCRIPTION
Description
---

fix `create_directories` for Windows long paths
add a test

This is a simple proposition but I would need help/guidance if it has to be further improved!
Thanks

Closes https://github.com/gulrak/filesystem/issues/125