### PR TITLE
Fix CMake config mode package finding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7.2)
-project(ghcfilesystem)
+project(ghc_filesystem)
 
 if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)


### PR DESCRIPTION
During a recent build, I realized that find_package was unable to find ghcfilesystem with it installed in my CMake prefix path (on Windows). After some poking around, I nailed it down to the final install directory not matching any of the search patterns in CMake's config mode package finder search procedure. The directory `ghc_filesystem-config.cmake` should be in must look like one of these in order to be found without special tweaks to the package find procedure:

```
<prefix-path>/ghc_filesystem-config.cmake
<prefix-path>/cmake/ghc_filesystem-config.cmake
<prefix-path>/ghc_filesystem*/ghc_filesystem-config.cmake
<prefix-path>/ghc_filesystem*/cmake/ghc_filesystem-config.cmake
<prefix-path>/lib/cmake/ghc_filesystem*/ghc_filesystem-config.cmake
<prefix-path>/lib/ghc_filesystem*/ghc_filesystem-config.cmake
<prefix-path>/lib/ghc_filesystem*/cmake/ghc_filesystem-config.cmake
<prefix-path>/ghc_filesystem*/lib/cmake/ghc_filesystem*/ghc_filesystem-config.cmake
<prefix-path>/ghc_filesystem*/lib/ghc_filesystem/ghc_filesystem-config.cmake
<prefix-path>/ghc_filesystem*/lib/ghc_filesystem/cmake/ghc_filesystem-config.cmake
```

Because the project name was ghcfilesystem, the default path was `<prefix-path>/ghcfilesystem/lib/cmake/ghc_filesystem/ghc_filesystem-config.cmake` (missing underscore). This problem likely doesn't manifest on Linux due to the way a `make install` works. Once I fixed the project name, CMake find_package was able to find the package with no problems.