### PR TITLE
Fix for issue #132

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -91,8 +91,8 @@ jobs:
             cc: clang
             cxx: clang++
 
-          - name: "Ubuntu 16.04 Clang 6.0"
-            os: ubuntu-16.04
+          - name: "Ubuntu 18.04 Clang 6.0"
+            os: ubuntu-18.04
             build_type: Release
             packages: ninja-build clang-6.0
             generator: Ninja
@@ -100,8 +100,8 @@ jobs:
             cc: clang-6.0
             cxx: clang++-6.0
 
-          - name: "Ubuntu 16.04 Clang 5.0"
-            os: ubuntu-16.04
+          - name: "Ubuntu 18.04 Clang 5.0"
+            os: ubuntu-18.04
             build_type: Release
             packages: ninja-build clang-5.0
             generator: Ninja

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -4740,7 +4740,7 @@ GHC_INLINE uintmax_t remove_all(const path& p, std::error_code& ec) noexcept
         return static_cast<uintmax_t>(-1);
     }
     std::error_code tec;
-    auto fs = status(p, tec);
+    auto fs = symlink_status(p, tec);
     if (exists(fs) && is_directory(fs)) {
         for (auto iter = directory_iterator(p, ec); iter != directory_iterator(); iter.increment(ec)) {
             if (ec && !detail::is_not_found_error(ec)) {

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -2607,6 +2607,10 @@ TEST_CASE("fs.op.remove_all - remove_all", "[filesystem][operations][fs.op.remov
     CHECK_NOTHROW(fs::remove_all("dir1/non-existing", ec));
     CHECK(!ec);
     CHECK(fs::remove_all("dir1/non-existing", ec) == 0);
+    if (is_symlink_creation_supported()) {
+        fs::create_directory_symlink("dir1", "dir1link");
+        CHECK(fs::remove_all("dir1link") == 1);
+    }
     CHECK(fs::remove_all("dir1") == 5);
     CHECK(fs::directory_iterator(t.path()) == fs::directory_iterator());
 }


### PR DESCRIPTION
Fix ```ghc::filesystem::remove_all``` behavior if argument is symlink (#132)
See https://en.cppreference.com/w/cpp/filesystem/remove:
> Symlinks are not followed (symlink is removed, not its target).

Update CI: Switch from ubuntu 16.04 to 18.04