### PR TITLE
Disable ``deprecated-declarations`` warning in tests (C++20)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ centos7_task:
 
 centos8_task:
   container:
-    image: centos:8
+    image: quay.io/centos/centos:stream8
   install_script: |
     yum group install -y "Development Tools"
     curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - -C /usr/local --strip-components 1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,15 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 set(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS ON)
 include(ParseAndAddCatchTests)
 
+function(SetTestCompileOptions target_name)
+    target_compile_options(${target_name} PRIVATE
+        $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -Wno-deprecated-declarations>
+        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror -Wno-deprecated-declarations>
+        $<$<CXX_COMPILER_ID:MSVC>:/WX /wd4996>
+        $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+endfunction()
+
 if(GHC_COVERAGE)
     message("Generating test runner for coverage run...")
     set(CMAKE_EXE_LINKER_FLAGS "${CMCMAKE_EXE_LINKER_FLAGS} --coverage") 
@@ -23,12 +32,7 @@ else()
     message("Generating test runner for normal test...")
     add_executable(filesystem_test filesystem_test.cpp catch.hpp)
     target_link_libraries(filesystem_test ghc_filesystem)
-    target_compile_options(filesystem_test PRIVATE
-        $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror>
-        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>
-        $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+    SetTestCompileOptions(filesystem_test)
     if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
         target_compile_definitions(filesystem_test PRIVATE _CRT_SECURE_NO_WARNINGS WIN32_LEAN_AND_MEAN NOMINMAX)
     endif()
@@ -42,10 +46,7 @@ else()
     if(WIN32)
         add_executable(filesystem_test_char filesystem_test.cpp catch.hpp)
         target_link_libraries(filesystem_test_char ghc_filesystem)
-        target_compile_options(filesystem_test_char PRIVATE
-            $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -Werror>
-            $<$<CXX_COMPILER_ID:GNU>:-Wall -Werror>
-            $<$<CXX_COMPILER_ID:MSVC>:/WX>)
+        SetTestCompileOptions(filesystem_test_char)
         if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
 		target_compile_definitions(filesystem_test_char PRIVATE _CRT_SECURE_NO_WARNINGS GHC_WIN_DISABLE_WSTRING_STORAGE_TYPE)
         else()
@@ -67,12 +68,7 @@ add_test(multifile_test multifile_test)
 
 add_executable(fwd_impl_test fwd_test.cpp impl_test.cpp)
 target_link_libraries(fwd_impl_test ghc_filesystem)
-target_compile_options(fwd_impl_test PRIVATE
-        $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror>
-        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>
-        $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+SetTestCompileOptions(fwd_impl_test)
 if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
 	target_compile_definitions(fwd_impl_test PRIVATE _CRT_SECURE_NO_WARNINGS WIN32_LEAN_AND_MEAN NOMINMAX)
 endif()
@@ -83,9 +79,4 @@ if(NOT MSVC)
     target_compile_options(exception PRIVATE -fno-exceptions)
 endif()
 target_include_directories(exception PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
-target_compile_options(exception PRIVATE
-        $<$<BOOL:${EMSCRIPTEN}>:-s DISABLE_EXCEPTION_CATCHING=0>
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror>
-        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:/WX>
-        $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+SetTestCompileOptions(exception)


### PR DESCRIPTION

Build errors (C++20 build):

```
phprus@mbp cxx20 % cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 ../..
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CMAKE_CXX_COMPILE_FEATURES: cxx_std_98;cxx_template_template_parameters;cxx_std_11;cxx_alias_templates;cxx_alignas;cxx_alignof;cxx_attributes;cxx_auto_type;cxx_constexpr;cxx_decltype;cxx_decltype_incomplete_return_types;cxx_default_function_template_args;cxx_defaulted_functions;cxx_defaulted_move_initializers;cxx_delegating_constructors;cxx_deleted_functions;cxx_enum_forward_declarations;cxx_explicit_conversions;cxx_extended_friend_declarations;cxx_extern_templates;cxx_final;cxx_func_identifier;cxx_generalized_initializers;cxx_inheriting_constructors;cxx_inline_namespaces;cxx_lambdas;cxx_local_type_template_args;cxx_long_long_type;cxx_noexcept;cxx_nonstatic_member_init;cxx_nullptr;cxx_override;cxx_range_for;cxx_raw_string_literals;cxx_reference_qualified_functions;cxx_right_angle_brackets;cxx_rvalue_references;cxx_sizeof_member;cxx_static_assert;cxx_strong_enums;cxx_thread_local;cxx_trailing_return_types;cxx_unicode_literals;cxx_uniform_initialization;cxx_unrestricted_unions;cxx_user_literals;cxx_variadic_macros;cxx_variadic_templates;cxx_std_14;cxx_aggregate_default_initializers;cxx_attribute_deprecated;cxx_binary_literals;cxx_contextual_conversions;cxx_decltype_auto;cxx_digit_separators;cxx_generic_lambdas;cxx_lambda_init_captures;cxx_relaxed_constexpr;cxx_return_type_deduction;cxx_variable_templates;cxx_std_17;cxx_std_20
Generating test runner for normal test...
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/phprus/Devel/gulrak/filesystem/build/cxx20
phprus@mbp cxx20 %

.....

[  5%] Building CXX object test/CMakeFiles/filesystem_test.dir/filesystem_test.cpp.o
cd /Users/phprus/Devel/gulrak/filesystem/build/cxx20/test && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -I/Users/phprus/Devel/gulrak/filesystem/include -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.1.sdk -Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -std=gnu++2a -MD -MT test/CMakeFiles/filesystem_test.dir/filesystem_test.cpp.o -MF CMakeFiles/filesystem_test.dir/filesystem_test.cpp.o.d -o CMakeFiles/filesystem_test.dir/filesystem_test.cpp.o -c /Users/phprus/Devel/gulrak/filesystem/test/filesystem_test.cpp
/Users/phprus/Devel/gulrak/filesystem/test/filesystem_test.cpp:607:15: error: 'u8path<char [7], ghc::filesystem::path>' is deprecated: use ghc::filesystem::path::path() with std::u8string instead [-Werror,-Wdeprecated-declarations]
    CHECK(fs::u8path("\xc3\xa4/\xe2\x82\xac").native() == fs::path::string_type("\xc3\xa4/\xe2\x82\xac"));
              ^
/Users/phprus/Devel/gulrak/filesystem/include/ghc/filesystem.hpp:640:3: note: 'u8path<char [7], ghc::filesystem::path>' has been explicitly marked deprecated here
[[deprecated("use ghc::filesystem::path::path() with std::u8string instead")]]
  ^
....
              ^
/Users/phprus/Devel/gulrak/filesystem/include/ghc/filesystem.hpp:640:3: note: 'u8path<char [7], ghc::filesystem::path>' has been explicitly marked deprecated here
[[deprecated("use ghc::filesystem::path::path() with std::u8string instead")]]
  ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[2]: *** [test/CMakeFiles/filesystem_test.dir/filesystem_test.cpp.o] Error 1
make[1]: *** [test/CMakeFiles/filesystem_test.dir/all] Error 2
make: *** [all] Error 2
make  0,91s user 0,04s system 98% cpu 0,968 total
phprus@mbp cxx20 %
```
