### PR TITLE
copy_file also copies permissions

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3956,6 +3956,14 @@ GHC_INLINE bool copy_file(const path& from, const path& to, copy_options options
         ::close(in);
         return false;
     }
+    if (st.permissions() != sf.permissions()) {
+        if (::fchmod(out, static_cast<int>(sf.permissions() & perms::all)) != 0) {
+            ec = detail::make_system_error();
+            ::close(in);
+            ::close(out);
+            return false;
+        }
+    }
     ssize_t br, bw;
     while ((br = ::read(in, buffer.data(), buffer.size())) > 0) {
         ssize_t offset = 0;

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3957,7 +3957,7 @@ GHC_INLINE bool copy_file(const path& from, const path& to, copy_options options
         return false;
     }
     if (st.permissions() != sf.permissions()) {
-        if (::fchmod(out, static_cast<int>(sf.permissions() & perms::all)) != 0) {
+        if (::fchmod(out, static_cast<mode_t>(sf.permissions() & perms::all)) != 0) {
             ec = detail::make_system_error();
             ::close(in);
             ::close(out);


### PR DESCRIPTION
Reproduce：
``` c++
    fs::path file1("temp1.txt");
    fs::path file2("temp2.txt");
    fs::permissions(file1, fs::perms::none);
    fs::permissions(file2, fs::perms::owner_write);
    fs::copy_file(file1, file2, fs::copy_options::overwrite_existing);
    assert(fs::status(file2).permissions() == fs::perms::none);
```
