### PR TITLE
Declare and export version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.7.2)
-project(ghcfilesystem)
+project(
+   ghcfilesystem,
+   VERSION 1.5.12
+)
 
 if (POLICY CMP0077)
     cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,16 @@ if(GHC_FILESYSTEM_WITH_INSTALL)
         "${PROJECT_BINARY_DIR}/cmake/ghc_filesystem-config.cmake"
         INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ghc_filesystem"
         PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
-    install(FILES "${PROJECT_BINARY_DIR}/cmake/ghc_filesystem-config.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ghc_filesystem")
+    write_basic_package_version_file(
+        "${PROJECT_BINARY_DIR}/cmake/ghc_filesystem-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
+    install(
+        FILES
+            "${PROJECT_BINARY_DIR}/cmake/ghc_filesystem-config.cmake"
+            "${PROJECT_BINARY_DIR}/cmake/ghc_filesystem-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ghc_filesystem"
+    )
     add_library(ghcFilesystem::ghc_filesystem ALIAS ghc_filesystem)
 endif()


### PR DESCRIPTION
This declares the project version in CMakeLists.txt and exports a `ghc_filesystem-config-version.cmake` file so that consumers of ghc_filesystem may rely on it.

Fixes #148 