### PR TITLE
Allow wchar_t constructors of fstreams on Windows when using libstdc++

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -1142,6 +1142,10 @@ GHC_FS_API void create_hard_link(const path& to, const path& new_hard_link, std:
 GHC_FS_API uintmax_t hard_link_count(const path& p, std::error_code& ec) noexcept;
 #endif
 
+#if defined(GHC_OS_WINDOWS) && (!defined(__GLIBCXX__) || (defined(_GLIBCXX_HAVE__WFOPEN) && defined(_GLIBCXX_USE_WCHAR_T)))
+#define GHC_HAS_FSTREAM_OPEN_WITH_WCHAR
+#endif
+
 // Non-C++17 add-on std::fstream wrappers with path
 template <class charT, class traits = std::char_traits<charT>>
 class basic_filebuf : public std::basic_filebuf<charT, traits>
@@ -1153,7 +1157,7 @@ public:
     const basic_filebuf& operator=(const basic_filebuf&) = delete;
     basic_filebuf<charT, traits>* open(const path& p, std::ios_base::openmode mode)
     {
-#if defined(GHC_OS_WINDOWS) && !defined(__GLIBCXX__)
+#ifdef GHC_HAS_FSTREAM_OPEN_WITH_WCHAR
         return std::basic_filebuf<charT, traits>::open(p.wstring().c_str(), mode) ? this : 0;
 #else
         return std::basic_filebuf<charT, traits>::open(p.string().c_str(), mode) ? this : 0;
@@ -1166,7 +1170,7 @@ class basic_ifstream : public std::basic_ifstream<charT, traits>
 {
 public:
     basic_ifstream() {}
-#if defined(GHC_OS_WINDOWS) && !defined(__GLIBCXX__)
+#ifdef GHC_HAS_FSTREAM_OPEN_WITH_WCHAR
     explicit basic_ifstream(const path& p, std::ios_base::openmode mode = std::ios_base::in)
         : std::basic_ifstream<charT, traits>(p.wstring().c_str(), mode)
     {
@@ -1189,7 +1193,7 @@ class basic_ofstream : public std::basic_ofstream<charT, traits>
 {
 public:
     basic_ofstream() {}
-#if defined(GHC_OS_WINDOWS) && !defined(__GLIBCXX__)
+#ifdef GHC_HAS_FSTREAM_OPEN_WITH_WCHAR
     explicit basic_ofstream(const path& p, std::ios_base::openmode mode = std::ios_base::out)
         : std::basic_ofstream<charT, traits>(p.wstring().c_str(), mode)
     {
@@ -1212,7 +1216,7 @@ class basic_fstream : public std::basic_fstream<charT, traits>
 {
 public:
     basic_fstream() {}
-#if defined(GHC_OS_WINDOWS) && !defined(__GLIBCXX__)
+#ifdef GHC_HAS_FSTREAM_OPEN_WITH_WCHAR
     explicit basic_fstream(const path& p, std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
         : std::basic_fstream<charT, traits>(p.wstring().c_str(), mode)
     {


### PR DESCRIPTION
Hi!
Currently, when using libstdc++ on Windows (e.g., MinGW), ghc::filesystem's streams open the file using the narrow string representation of the path.

However, recent versions of libstdc++ have added support for opening file streams directly using wchar_t paths (https://github.com/gcc-mirror/gcc/commit/b02923592a55b52d796656c5b4f34a964a2604a9).

Using the wide/native string type for opening the file streams is preferred on Windows, especially for supporting paths with Unicode characters.

This PR introduces a new #define called `GHC_HAS_FSTREAM_OPEN_WITH_WCHAR` (I could not find any better name 😅).
It is defined when the OS is Windows and either we are not using libstdc++ (e.g., libc++ or Microsoft's STL) or the libstdc++ supports opening files using wchar_t paths.
For checking this latter case, I used the same preprocessor check done in libstdc++ (e.g., https://github.com/gcc-mirror/gcc/blob/b02923592a55b52d796656c5b4f34a964a2604a9/libstdc%2B%2B-v3/include/std/fstream#L536)