### PR TITLE
Added a missing header for macos strcasecmp

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -157,7 +157,7 @@
 #else
 #include <sys/statvfs.h>
 #endif
-#ifdef GHC_OS_CYGWIN
+#if defined(GHC_OS_CYGWIN) || defined(GHC_OS_APPLE)
 #include <strings.h>
 #endif
 #if !defined(__ANDROID__) || __ANDROID_API__ >= 26


### PR DESCRIPTION
Hi there!

I am currently using v1.5.14 as a submodule in my cmake project on macOS. I have a problem with the strcasecmp function:
```
.../vendor/filesystem/include/ghc/filesystem.hpp:1895:15: error: no member named 'strcasecmp' in the global namespace
return 0 == ::strcasecmp(str1, str2);
            ~~^
1 error generated.
```

As far as I am aware, the `#include <strings.h>` header is required for this function, and it is not included for the macOS build.

Or am I doing something wrong?