### PR TITLE
Add reference to Bazel rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ The `CMakeLists.txt` offers a few options to customize its behavior:
   `CMAKE_CXX_COMPILE_FEATURES` when the detection of C++17 or C++20 for additional tests
   is not working (e.g. `cxx_std_20` to enforce building a `filesystem_test_cpp20` with C++20).
 
+### Bazel
+
+Please use [hedronvision/bazel-cc-filesystem-backport](https://github.com/hedronvision/bazel-cc-filesystem-backport), which will automatically set everything up for you.
+
 ### Versioning
 
 There is a version macro `GHC_FILESYSTEM_VERSION` defined in case future changes


### PR DESCRIPTION
Hi again, Steffen!

Thanks again for such a wonderful library. We've been using it for months now and really appreciate it.

I'd promised you Bazel rules in https://github.com/gulrak/filesystem/pull/167#issuecomment-1659529723. Now that they're battle-tested (especially as a transitive dep) I'm following up with that one-liner PR linking to them in the README that you'd 👍🏻'd. Should make usage stupid simple for Bazel users.

Cheers,
Chris