### PR TITLE
Fix lexically_relative return when base path evaluates to *this

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3306,6 +3306,9 @@ GHC_INLINE path path::lexically_relative(const path& base) const
             --count;
         }
     }
+    if (count == 0 && (a == end() || empty())) {
+        return path(".");
+    }
     if (count < 0) {
         return path();
     }

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3306,7 +3306,7 @@ GHC_INLINE path path::lexically_relative(const path& base) const
             --count;
         }
     }
-    if (count == 0 && (a == end() || empty())) {
+    if (count == 0 && (a == end() || a->empty())) {
         return path(".");
     }
     if (count < 0) {

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -965,6 +965,9 @@ TEST_CASE("fs.path.gen - path generation", "[filesystem][path][fs.path.gen]")
     // lexically_relative()
     CHECK(fs::path("/a/d").lexically_relative("/a/b/c") == "../../d");
     CHECK(fs::path("/a/b/c").lexically_relative("/a/d") == "../b/c");
+    CHECK(fs::path("/a/b/c").lexically_relative("/a/b/c/d/..") == ".");
+    CHECK(fs::path("").lexically_relative("/a/..") == "");
+    CHECK(fs::path("").lexically_relative("a/..") == ".");
     CHECK(fs::path("a/b/c").lexically_relative("a") == "b/c");
     CHECK(fs::path("a/b/c").lexically_relative("a/b/c/x/y") == "../..");
     CHECK(fs::path("a/b/c").lexically_relative("a/b/c") == ".");

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -966,6 +966,7 @@ TEST_CASE("fs.path.gen - path generation", "[filesystem][path][fs.path.gen]")
     CHECK(fs::path("/a/d").lexically_relative("/a/b/c") == "../../d");
     CHECK(fs::path("/a/b/c").lexically_relative("/a/d") == "../b/c");
     CHECK(fs::path("/a/b/c").lexically_relative("/a/b/c/d/..") == ".");
+    CHECK(fs::path("/a/b/c/").lexically_relative("/a/b/c/d/..") == ".");
     CHECK(fs::path("").lexically_relative("/a/..") == "");
     CHECK(fs::path("").lexically_relative("a/..") == ".");
     CHECK(fs::path("a/b/c").lexically_relative("a") == "b/c");


### PR DESCRIPTION
Fix the return of lexally_relative when called with the following values:

"/a/b/c".lexally_relative("/a/b/c/d/..") == "."

The proposed change is based on the following line from the [documentation](https://en.cppreference.com/w/cpp/filesystem/path/lexically_normal):

"otherwise, if N = 0 and a == end() || a->empty(), returns path("."), "