### PR TITLE
fix  `lexically_normal` for `../foo/../../bar/`

### DIFF
--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -3261,11 +3261,12 @@ GHC_INLINE path path::lexically_normal() const
             continue;
         }
         else if (s == ".." && !dest.empty()) {
-            auto root = root_path();
-            if (dest == root) {
+            if (dest == root_path()) {
                 continue;
             }
-            else if (*(--dest.end()) != "..") {
+
+            const auto filename = *(--dest.end());
+            if (filename != ".." && !(filename.empty() && dest.has_parent_path() && dest.parent_path() == "..")) {
                 if (dest._path.back() == preferred_separator) {
                     dest._path.pop_back();
                 }

--- a/test/filesystem_test.cpp
+++ b/test/filesystem_test.cpp
@@ -955,6 +955,7 @@ TEST_CASE("fs.path.gen - path generation", "[filesystem][path][fs.path.gen]")
     CHECK(fs::path("ab/cd/ef/../../qw").lexically_normal() == "ab/qw");
     CHECK(fs::path("a/b/../../../c").lexically_normal() == "../c");
     CHECK(fs::path("../").lexically_normal() == "..");
+    CHECK(fs::path("../foo/../../bar/").lexically_normal() == "../../bar/");
 #ifdef GHC_OS_WINDOWS
     CHECK(fs::path("\\/\\///\\/").lexically_normal() == "/");
     CHECK(fs::path("a/b/..\\//..///\\/../c\\\\/").lexically_normal() == "../c/");


### PR DESCRIPTION
* originally this was "normalizing" to `"bar"` when it should be `"../../bar"`
* this fixes #185