### PR TITLE
Avoid GNU `getcwd` extension behavior

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,25 +11,24 @@ freebsd_task:
   test_script: |
     sudo -u testuser .ci/unix-test.sh
 
-centos7_task:
+rockylinux8_task:
   container:
-    image: centos:7
+    image: docker.io/rockylinux:8
   install_script: |
-    yum install -y centos-release-scl
-    yum install -y devtoolset-9
-    curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - -C /usr/local --strip-components 1
+    dnf group install -y "Development Tools"
+    dnf install cmake -y
   build_script: |
-    source /opt/rh/devtoolset-9/enable && PATH=$PATH:/usr/local/bin .ci/unix-build.sh
+    .ci/unix-build.sh
   test_script: |
-    PATH=$PATH:/usr/local/bin .ci/unix-test.sh
+    .ci/unix-test.sh
 
-centos8_task:
+rockylinux9_task:
   container:
-    image: quay.io/centos/centos:stream8
+    image: docker.io/rockylinux:9
   install_script: |
-    yum group install -y "Development Tools"
-    curl -L https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz | tar xzvf - -C /usr/local --strip-components 1
+    dnf group install -y "Development Tools"
+    dnf install cmake -y
   build_script: |
-    PATH=$PATH:/usr/local/bin .ci/unix-build.sh
+    .ci/unix-build.sh
   test_script: |
-    PATH=$PATH:/usr/local/bin .ci/unix-test.sh
+    .ci/unix-test.sh

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -4229,7 +4229,7 @@ GHC_INLINE path current_path(std::error_code& ec)
     }
     return path(std::wstring(buffer.get()), path::native_format);
 #elif defined(__GLIBC__)
-    std::unique_ptr<char, decltype(&std::free)> buffer { ::getcwd(NULL, 0), std::free };
+    std::unique_ptr<char, decltype(&std::free)> buffer { ::get_current_dir_name(), std::free };
     if (buffer == nullptr) {
         ec = detail::make_system_error();
         return path();


### PR DESCRIPTION
GNU `getcwd` can allocate a buffer if passed `NULL` for it. This is an extension which is e.g., not recognized by clang-tidy-19's `StdCLibraryFunctions` check[^1] which emits a diagnostic on a violated precondition `buf != NULL`,

```
The 1st argument to 'getcwd' is NULL but should not be NULL [clang-analyzer-unix.StdCLibraryFunctions,-warnings-as-errors]
[build]  3987 |     std::unique_ptr<char, decltype(&std::free)> buffer{::getcwd(NULL, 0), std::free};
```

This patch modifies this use of `getcwd` with this extension behavior to instead use `get_current_dir_name` which is also a GNU extension, but does not trigger this diagnostic.

[^1]: https://clang.llvm.org/docs/analyzer/checkers.html#unix-stdclibraryfunctions-c