### PR TITLE
Fix building on Windows with MSYS2

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -139,12 +139,12 @@ jobs:
           sudo apt install ${{ matrix.config.packages }}
 
       - name: Install dependencies on windows (MSVC)
-        if: matrix.config.msystem == ''
+        if: startsWith(matrix.config.os, 'windows') && matrix.config.msystem == ''
         run: |
           choco install ${{ matrix.config.packages }}
 
       - name: Install dependencies on windows (MSYS2)
-        if: matrix.config.msystem != ''
+        if: startsWith(matrix.config.os, 'windows') && matrix.config.msystem != ''
         uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.config.msystem }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -139,7 +139,7 @@ jobs:
           sudo apt install ${{ matrix.config.packages }}
 
       - name: Install dependencies on windows (MSVC)
-        if: startsWith(matrix.config.os, 'windows')
+        if: matrix.config.msystem == ''
         run: |
           choco install ${{ matrix.config.packages }}
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -157,6 +157,7 @@ jobs:
           brew install ${{ matrix.config.packages }}
 
       - name: Configure project
+        if: matrix.config.msystem == ''
         shell: bash
         run: |
           export CC=${{ matrix.config.cc }}
@@ -171,12 +172,43 @@ jobs:
           args+=(-DCMAKE_INSTALL_PREFIX:PATH=install)
           cmake "${args[@]}"
 
+      - name: Configure project (MSYS2)
+        if: matrix.config.msystem != ''
+        shell: msys2 {0}
+        run: |
+          export CC=${{ matrix.config.cc }}
+          export CXX=${{ matrix.config.cxx }}
+          ninja --version
+          cmake --version
+          mkdir build
+          mkdir install
+          args=(-G "${{ matrix.config.generator }}" -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }})
+          [[ "${{ matrix.config.build_type }}" == "Debug" ]] && args+=(-DGHC_COVERAGE=ON)
+          [[ -n "${{ matrix.config.msystem }}" ]] && args+=(-DGHC_FILESYSTEM_BUILD_STD_TESTING=NO)
+          args+=(-DCMAKE_INSTALL_PREFIX:PATH=install)
+          cmake "${args[@]}"
+
       - name: Build project
+        if: matrix.config.msystem == ''
         shell: bash
         run: |
           cmake --build build --config ${{ matrix.config.build_type }}
 
+      - name: Build project (MSYS2)
+        if: matrix.config.msystem != ''
+        shell: msys2 {0}
+        run: |
+          cmake --build build --config ${{ matrix.config.build_type }}
+
       - name: Run tests
+        if: matrix.config.msystem == ''
+        shell: bash
+        run: |
+          cd build && ctest -C ${{ matrix.config.build_type }}
+
+      - name: Run tests (MSYS2)
+        if: matrix.config.msystem != ''
+        shell: msys2 {0}
         run: |
           cd build && ctest -C ${{ matrix.config.build_type }}
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -85,11 +85,33 @@ jobs:
           - name: "Windows MSVC 2019"
             os: windows-2019
             build_type: Release
+            build_std_testing: 'OFF'
             packages: ninja
             generator: "Visual Studio 16 2019"
             compatibility: "cxx_std_11;cxx_std_17;cxx_std_20"
             cc: cl
             cxx: cl
+
+          - name: "Windows MSYS2 UCRT64"
+            os: windows-2019
+            msystem: ucrt64
+            build_type: Release
+            build_std_testing: 'OFF'
+            packages: mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-ninja
+            generator: Ninja
+            compatibility: "cxx_std_11;cxx_std_17;cxx_std_20"
+            cc: gcc
+            cxx: g++
+
+          - name: "Windows MSYS2 CLANG64"
+            os: windows-2019
+            msystem: clang64
+            build_type: Release
+            packages: mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-ninja
+            generator: Ninja
+            compatibility: "cxx_std_11;cxx_std_17;cxx_std_20"
+            cc: clang
+            cxx: clang++
 
           - name: "macOS 13 AppleClang"
             os: macos-13
@@ -116,10 +138,18 @@ jobs:
           sudo apt update
           sudo apt install ${{ matrix.config.packages }}
 
-      - name: Install dependencies on windows
+      - name: Install dependencies on windows (MSVC)
         if: startsWith(matrix.config.os, 'windows')
         run: |
           choco install ${{ matrix.config.packages }}
+
+      - name: Install dependencies on windows (MSYS2)
+        if: matrix.config.msystem != ''
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.config.msystem }}
+          update: true
+          pacboy: ${{ matrix.config.packages }}
 
       - name: Install dependencies on macOS
         if: startsWith(matrix.config.os, 'macos')
@@ -135,11 +165,11 @@ jobs:
           cmake --version
           mkdir build
           mkdir install
-          if [[ "${{ matrix.config.build_type }}" == "Debug" ]]; then
-            cmake -G "${{ matrix.config.generator }}" -S . -B build -DCMAKE_BUILD_TYPE=Debug -DGHC_COVERAGE=ON -DGHC_FILESYSTEM_TEST_COMPILE_FEATURES="${{ matrix.config.compatibility }}" -DCMAKE_INSTALL_PREFIX:PATH=install
-          else
-            cmake -G "${{ matrix.config.generator }}" -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DGHC_FILESYSTEM_TEST_COMPILE_FEATURES="${{ matrix.config.compatibility }}" -DCMAKE_INSTALL_PREFIX:PATH=install
-          fi
+          args=(-G "${{ matrix.config.generator }}" -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }})
+          [[ "${{ matrix.config.build_type }}" == "Debug" ]] && args+=(-DGHC_COVERAGE=ON)
+          [[ -n "${{ matrix.config.msystem }}" ]] && args+=(-DGHC_FILESYSTEM_BUILD_STD_TESTING=NO)
+          args+=(-DCMAKE_INSTALL_PREFIX:PATH=install)
+          cmake "${args[@]}"
 
       - name: Build project
         shell: bash
@@ -167,4 +197,3 @@ jobs:
         with:
           path-to-lcov: ${{ github.workspace }}/build/coverage.info
           github-token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -97,7 +97,7 @@ jobs:
             msystem: ucrt64
             build_type: Release
             build_std_testing: 'OFF'
-            packages: mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-ninja
+            packages: cmake gcc ninja
             generator: Ninja
             compatibility: "cxx_std_11;cxx_std_17;cxx_std_20"
             cc: gcc
@@ -107,7 +107,7 @@ jobs:
             os: windows-2019
             msystem: clang64
             build_type: Release
-            packages: mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-ninja
+            packages: cmake clang ninja
             generator: Ninja
             compatibility: "cxx_std_11;cxx_std_17;cxx_std_20"
             cc: clang

--- a/cmake/GhcHelper.cmake
+++ b/cmake/GhcHelper.cmake
@@ -40,7 +40,7 @@ if (CMAKE_COMPILER_IS_GNUCXX AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 8.0 O
     if(${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
         target_link_libraries(${targetName} network)
     endif()
-    target_compile_options(${targetName} PRIVATE $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+    target_compile_options(${targetName} PRIVATE $<$<OR:$<BOOL:${CYGWIN}>,$<BOOL:${MINGW}>>:-Wa,-mbig-obj>)
     target_compile_definitions(${targetName} PRIVATE USE_STD_FS)
 endif()
 
@@ -69,7 +69,7 @@ macro(AddTestExecutableWithStdCpp cppStd)
             $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -Wno-error=deprecated-declarations>
             $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror -Wno-error=deprecated-declarations>
             $<$<CXX_COMPILER_ID:MSVC>:/WX /wd4996>
-            $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>
+            $<$<OR:$<BOOL:${CYGWIN}>,$<BOOL:${MINGW}>>:-Wa,-mbig-obj>
             $<$<BOOL:${GHC_COVERAGE}>:--coverage>)
     if(CMAKE_CXX_COMPILER_ID MATCHES MSVC)
         target_compile_definitions(filesystem_test_cpp${cppStd} PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/include/ghc/filesystem.hpp
+++ b/include/ghc/filesystem.hpp
@@ -1941,7 +1941,7 @@ GHC_INLINE void create_symlink(const path& target_name, const path& new_symlink,
         ec = detail::make_error_code(detail::portable_error::not_supported);
         return;
     }
-#if defined(__GNUC__) && __GNUC__ >= 8
+#if (defined(__GNUC__) && __GNUC__ >= 8) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__)
@@ -1949,7 +1949,7 @@ GHC_INLINE void create_symlink(const path& target_name, const path& new_symlink,
 #pragma warning(disable : 4191)
 #endif
     static CreateSymbolicLinkW_fp api_call = reinterpret_cast<CreateSymbolicLinkW_fp>(GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "CreateSymbolicLinkW"));
-#if defined(__GNUC__) && __GNUC__ >= 8
+#if (defined(__GNUC__) && __GNUC__ >= 8) || defined(__clang__)
 #pragma GCC diagnostic pop
 #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__)
 #pragma warning(pop)
@@ -1970,7 +1970,7 @@ GHC_INLINE void create_symlink(const path& target_name, const path& new_symlink,
 
 GHC_INLINE void create_hardlink(const path& target_name, const path& new_hardlink, std::error_code& ec)
 {
-#if defined(__GNUC__) && __GNUC__ >= 8
+#if (defined(__GNUC__) && __GNUC__ >= 8) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__)
@@ -1978,7 +1978,7 @@ GHC_INLINE void create_hardlink(const path& target_name, const path& new_hardlin
 #pragma warning(disable : 4191)
 #endif
     static CreateHardLinkW_fp api_call = reinterpret_cast<CreateHardLinkW_fp>(GetProcAddress(GetModuleHandleW(L"kernel32.dll"), "CreateHardLinkW"));
-#if defined(__GNUC__) && __GNUC__ >= 8
+#if (defined(__GNUC__) && __GNUC__ >= 8) || defined(__clang__)
 #pragma GCC diagnostic pop
 #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__clang__)
 #pragma warning(pop)
@@ -2116,6 +2116,13 @@ private:
     element_type _handle;
 };
 
+// It seems GCC doesn't catch this, but Clang does
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=72751
+#if defined(__clang__) && defined(__MINGW32__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
+
 #ifndef REPARSE_DATA_BUFFER_HEADER_SIZE
 typedef struct _REPARSE_DATA_BUFFER
 {
@@ -2150,6 +2157,10 @@ typedef struct _REPARSE_DATA_BUFFER
 #ifndef MAXIMUM_REPARSE_DATA_BUFFER_SIZE
 #define MAXIMUM_REPARSE_DATA_BUFFER_SIZE (16 * 1024)
 #endif
+#endif
+
+#if defined(__clang__) && defined(__MINGW32__)
+#pragma clang diagnostic pop
 #endif
 
 template <class T>
@@ -2246,11 +2257,21 @@ GHC_INLINE void timeToFILETIME(time_t t, FILETIME& ft)
     ft.dwHighDateTime = ull.HighPart;
 }
 
+// Not sure why GCC doesn't catch this here, but Clang does
+#if defined(__clang__) && defined(__MINGW32__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+
 template <typename INFO>
 GHC_INLINE uintmax_t hard_links_from_INFO(const INFO* info)
 {
     return static_cast<uintmax_t>(-1);
 }
+
+#if defined(__clang__) && defined(__MINGW32__)
+#pragma clang diagnostic pop
+#endif
 
 template <>
 GHC_INLINE uintmax_t hard_links_from_INFO<BY_HANDLE_FILE_INFORMATION>(const BY_HANDLE_FILE_INFORMATION* info)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ function(SetTestCompileOptions target_name)
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Werror -Wno-deprecated-declarations>
         $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wpedantic -Wno-psabi -Werror -Wno-deprecated-declarations>
         $<$<CXX_COMPILER_ID:MSVC>:/WX /wd4996>
-        $<$<BOOL:${CYGWIN}>:-Wa,-mbig-obj>)
+        $<$<OR:$<BOOL:${CYGWIN}>,$<BOOL:${MINGW}>>:-Wa,-mbig-obj>)
 endfunction()
 
 if(GHC_COVERAGE)


### PR DESCRIPTION
This PR:
- fixes building on Windows with MSYS2 GCC (UCRT64) (adds `-mbig-obj` to `CXXFLAGS` by default for MinGW in general, instead of just Cygwin)
- fixes building on Windows with Clang (CLANG64) (fixes the GCC `#pragma`s to also work for Clang, and adds more to fix the things Clang catches that GCC doesn't)
- adds MSYS2 to CI

Tests against `std::filesystem` remain broken, and must be disabled using `-DGHC_FILESYSTEM_BUILD_STD_TEST=NO`, but at least `-DCMAKE_CXX_FLAGS=-Wa,-mbig-obj` is no longer required to be passed explicitly. Additionally, also add MSYS2 to CI.

If any of the above are undesirable, it can be reverted and/or added in a separate PR.

Fixes https://github.com/gulrak/filesystem/issues/189