### PR TITLE
Update CMake Min Requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.10)
 project(
    ghcfilesystem,
    VERSION 1.5.15


### PR DESCRIPTION
cmake 4.0 has deprecated version 3.9 and lower and started error'ing out when in use. (you can currently get around it by adding `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` but thats just a workaround)

updating from 3.7 to 3.10 should be relatively safe, as far as cmake policies go, changes have been [minimal](https://cmake.org/cmake/help/v4.0/manual/cmake-policies.7.html#policies-introduced-by-cmake-3-10) moving from 3.7 to 3.10