### PR TITLE
Add a FreeBSD job on GitHub Actions to replace the retired Cirrus CI task

### DIFF
--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -1,0 +1,31 @@
+name: FreeBSD
+
+on: [push, pull_request]
+
+jobs:
+
+  freebsd:
+    name: FreeBSD 14
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build and test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: '14'
+          usesh: true
+          copyback: false
+          cache-after-prepare: true
+          prepare: pkg install -y cmake
+          run: |
+            set -e
+            set -u
+            set -x
+            # Same as .cirrus.yml did: the suite must not run as root, or the
+            # permission tests never see the errors they check for.
+            pw groupadd testgrp
+            pw useradd testuser -g testgrp -w none -m
+            chown -R testuser:testgrp .
+            wd=$(pwd)
+            su -l testuser -c "cd $wd && sh .ci/unix-build.sh"
+            su -l testuser -c "cd $wd && sh .ci/unix-test.sh"


### PR DESCRIPTION
Cirrus CI shut down on 2026-06-01.  The last freebsd check-run here is on
603dacf6 (2026-01-02), and 23 commits have landed since with no FreeBSD
result -- so "Automated CI currently covers macOS, Windows, Ubuntu, Rocky
Linux, and FreeBSD" in the README, and the "FreeBSD 14" line under
Platforms, are no longer true.

This adds .github/workflows/build_freebsd.yml.  It runs the same
.ci/unix-build.sh and .ci/unix-test.sh that freebsd_task ran, as a
non-root testuser created the same way, in a FreeBSD VM on a
GitHub-hosted runner.  Only cmake is installed, as before.

Verified on my fork.  FreeBSD 14.4, 3m49s for the whole job:

  Tests run as user: testuser
  100% tests passed, 0 tests failed out of 199
  Total Test time (real) = 4.63 sec

  https://github.com/neilpang/filesystem/actions/runs/33881441561/job/101050809350

release is '14' to match the Platforms list; adding '15' is a one-line
change if you want it.

One observation, not gated and not a regression: the std_filesystem_test
run that unix-test.sh already tolerates with "|| true" reports 4 failed
cases and 9 failed assertions against FreeBSD's libc++.  I have not
classified them.  Three of the nine:

  CHECK( "///,foo,bar" == iterateResult(fs::path("///foo/bar")) )
  with expansion: "///,foo,bar" == "/,foo,bar"

  CHECK_THROWS_AS( fs::canonical(""), fs::filesystem_error )
  because no exception was thrown where one was expected

  CHECK( fs::canonical("", ec) == "" )
  with expansion: "/home/runner/work/filesystem/filesystem/build" == ""

The rest are directory_entry::refresh(), assign("") and
replace_filename() not throwing where the standard asks.  ghc::filesystem
itself is unaffected: ctest is 199/199.

The rockylinux8 and rockylinux9 tasks in .cirrus.yml are dead too.  They
would run as containers on a GitHub runner; I left them alone here.
